### PR TITLE
Изменил версию ubuntu и сделал выход через exit процесс

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             fileName: "sw_linux_x64"
             file: "sw"
           - os: windows-latest

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::fs;
+use std::{fs, process::exit};
 
 pub fn get_config() -> Settings {
     let config = {
@@ -21,7 +21,8 @@ pub fn get_config() -> Settings {
                     serde_json::to_string_pretty(&config).unwrap(),
                 )
                 .expect("Can't write to file");
-                panic!("Config not found, a default config was created. \nPlease configure it.");
+                println!("Config not found, a default config was created. \nPlease configure it.");
+                exit(1);
             }
         };
         serde_json::from_str::<Settings>(&s).unwrap()


### PR DESCRIPTION
Ubuntu собирает бинарь лаунчера libc6 версии 2.39, но в stable ветки Debian 12 у неё версия 2.36 (типикал Debian коммьюнити, которое не обнволяет пакеты). Сделал выход проограммы при генерации sw_config через exit() метод (это же не ошибка а просто его генерация)